### PR TITLE
Table total formula refactor

### DIFF
--- a/public/decorators/agg_table.js
+++ b/public/decorators/agg_table.js
@@ -1,5 +1,4 @@
 import { uiModules } from 'ui/modules';
-import { TableTotalFormulaProvider } from './lib/apply_formula_total';
 
 // Defines the $scope.totalFunc allowed to perform the calculations
 const TOTAL_FUNCTIONS_ALLOWED = ['sum', 'avg'];
@@ -12,9 +11,8 @@ uiModules
       const directive = $delegate[0];
       const controllerName = directive.controller;
 
-      directive.controller = function($scope, Private) {
+      directive.controller = function ($scope, Private) {
         angular.extend(this, $controller(controllerName, { $scope: $scope }));
-        const applyFormula = Private(TableTotalFormulaProvider);
 
         // This will run after $scope.$watch('table') from default controller
         $scope.$watch('table', () => {
@@ -28,41 +26,21 @@ uiModules
           const shouldApplyFormula = hasColumns && hasFormulas && isTotalFunctionAllowed;
           if (!shouldApplyFormula) return;
 
-          // Adds some attributes to every $scope.formattedColumns element
+          // Overrides formattedColumn.total if needed
           $scope.formattedColumns = table.columns.map(function (col, i) {
             const formattedColumn = $scope.formattedColumns[i];
             const agg = table.aggConfig(col);
             const field = agg.getField();
             const isFieldDate = field && field.type === 'date';
-            const sum = tableRows => tableRows.reduce((prev, curr) => {
-              // some metrics return undefined for some of the values
-              // derivative is an example of this as it returns undefined in the first row
-              if (curr[i].value === undefined) return prev;
-              return prev + curr[i].value;
-            }, 0);
-            
-            // Adds formatter into formattedColumn
-            formattedColumn.formatter = agg.fieldFormatter('text');
+            const hasFormula = agg.type && agg.type.name === 'datasweet_formula';
+            if (isFieldDate || !hasFormula) return formattedColumn;
 
-            // Adds totalRaw into formattedColumn
-            if (!isFieldDate) {
-              switch ($scope.totalFunc) {
-                case 'sum':
-                  formattedColumn.totalRaw = sum(table.rows);
-                  break;
-                case 'avg':
-                  formattedColumn.totalRaw = sum(table.rows) / table.rows.length;
-                  break;
-                default:
-                  break;
-              }
-            }
+            const formatter = agg.fieldFormatter('text');
+            const totalRaw = table.totals[i][$scope.totalFunc];
+            formattedColumn.total = formatter(totalRaw);
 
             return formattedColumn;
           });
-
-          // Applies formula
-          applyFormula($scope.formattedColumns, table.columns);
         });
       };
 

--- a/public/decorators/agg_table.js
+++ b/public/decorators/agg_table.js
@@ -11,7 +11,7 @@ uiModules
       const directive = $delegate[0];
       const controllerName = directive.controller;
 
-      directive.controller = function ($scope, Private) {
+      directive.controller = function ($scope) {
         angular.extend(this, $controller(controllerName, { $scope: $scope }));
 
         // This will run after $scope.$watch('table') from default controller

--- a/public/decorators/lib/apply_hidden.js
+++ b/public/decorators/lib/apply_hidden.js
@@ -6,6 +6,7 @@ export function AggResponseHiddenColumnsProvider() {
       table.tables.forEach(t => mutate(t, hiddenCols));
     } else {
       table.columns = reject(table.columns, (c, i) => includes(hiddenCols, i));
+      table.totals = reject(table.totals, (c, i) => includes(hiddenCols, i));
       table.rows = map(table.rows, row => reject(row, (r, i) => includes(hiddenCols, i)));
     }
   };

--- a/public/decorators/response_writer.js
+++ b/public/decorators/response_writer.js
@@ -1,16 +1,19 @@
 import { TabbedAggResponseWriterProvider } from 'ui/agg_response/tabify/_response_writer';
 import { AggResponseHiddenColumnsProvider } from './lib/apply_hidden';
 import { AggResponseFormulaProvider } from './lib/apply_formula';
+import { TableTotalFormulaProvider } from './lib/apply_formula_total';
 
 export function decorateTabbedAggResponseWriterProvider(Private) {
   const TabbedAggResponseWriter = Private(TabbedAggResponseWriterProvider);
   const applyFormulas = Private(AggResponseFormulaProvider);
+  const applyFormulaTotal = Private(TableTotalFormulaProvider);
   const applyHiddenCols = Private(AggResponseHiddenColumnsProvider);
 
   const responseFn = TabbedAggResponseWriter.prototype.response;
   TabbedAggResponseWriter.prototype.response = function () {
     const resp = responseFn.apply(this, arguments);
     applyFormulas(this.columns, resp);
+    applyFormulaTotal(this.columns, resp);
     applyHiddenCols(this.columns, resp);
     return resp;
   };


### PR DESCRIPTION
Guys, I found another bug on table total formula approach.

When you configure the formula using a hidden metric column, the table total is not correctly calculated. Example:
- Visible columns (correct values):
![total-refactor-1](https://user-images.githubusercontent.com/16384428/41166624-1fb6f64e-6b17-11e8-9c02-34207d7140a8.png)

- Hidden columns:
![total-refactor-2](https://user-images.githubusercontent.com/16384428/41166631-230e259c-6b17-11e8-8166-12a793188aea.png)

This happens because we apply the hidden configuration in `TabbedAggResponseWriter.response` step. To fix this, I've moved `TableTotalFormulaProvider` to this section of code (instead of handling it on `AggTable` decorator).

If you have any suggestion or change requests, please let me know!